### PR TITLE
use strict-mode 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "^3.8.4",
     "lodash": "^4.17.4",
     "parse-link-header": "1.0.0",
-    "strict-mode": "1.1.2"
+    "strict-mode": "^1.1.2"
   },
   "devDependencies": {
     "@okta/openapi": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "isomorphic-fetch": "2.2.1",
     "js-yaml": "^3.8.4",
     "lodash": "^4.17.4",
-    "parse-link-header": "1.0.0"
+    "parse-link-header": "1.0.0",
+    "strict-mode": "1.1.2"
   },
   "devDependencies": {
     "@okta/openapi": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-sdk-nodejs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Okta API wrapper for Node.js",
   "engines": {
     "node": ">=4.8.3"

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,22 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+"use strict";
+
+let client;
+
+/*
+strict-mode ensures all files included from this point forward
+have strict mode enabled.
+This is particularly useful while using this library in applications where passing
+a --use_strict flag is not possible.
+  OR
+An alternative to this is include the "use strict" declaration on top of each file using ES6 features
+*/
+require('strict-mode')(function () {
+  client = require('./client');
+});
 
 module.exports = {
-  Client: require('./client')
+  Client: client;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -27,5 +27,5 @@ require('strict-mode')(function () {
 });
 
 module.exports = {
-  Client: client;
+  Client: client
 };


### PR DESCRIPTION
okta-sdk-nodejs uses ES6 features but does not use the "use strict" declarative, this causes failures in unity-core. 
Ideal solution is to use Babel and transpile this library to ES5, there are difficulties doing this in meteor. Use this fork untill we get babel working for unity-core